### PR TITLE
Fix: sidebar schema selection, explain tab, autocomplete, run/explain flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "@vitest/coverage-v8": "^1.6.1",
         "autoprefixer": "^10.4.19",
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.2",
@@ -65,6 +66,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -399,6 +414,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1054,6 +1076,16 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -2250,6 +2282,34 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.6.1.tgz",
+      "integrity": "sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.4",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3986,6 +4046,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4201,6 +4268,60 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -4472,6 +4593,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {
@@ -5967,6 +6116,45 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/coverage-v8": "^1.6.1",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlpilot",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri = { version = "2", features = [] }
 
 [package]
 name = "sqlpilot"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "AI-powered MySQL GUI management tool"
 

--- a/src-tauri/crates/mas-ai/src/tools.rs
+++ b/src-tauri/crates/mas-ai/src/tools.rs
@@ -339,7 +339,7 @@ fn handle_run_select_query(
         trimmed.to_string()
     };
 
-    let results = block_on_async(executor.execute(connection_id, &limited_sql))
+    let results = block_on_async(executor.execute(connection_id, &limited_sql, None))
         .map_err(|e| e.to_string())?;
 
     format_query_results(&results)
@@ -351,7 +351,7 @@ fn handle_explain_query(
     sql: &str,
 ) -> Result<String, String> {
     let explain_sql = format!("EXPLAIN {}", sql.trim().trim_end_matches(';'));
-    let results = block_on_async(executor.execute(connection_id, &explain_sql))
+    let results = block_on_async(executor.execute(connection_id, &explain_sql, None))
         .map_err(|e| e.to_string())?;
 
     format_query_results(&results)
@@ -406,7 +406,7 @@ fn handle_run_query(
     connection_id: &str,
     sql: &str,
 ) -> Result<String, String> {
-    let results = block_on_async(executor.execute(connection_id, sql.trim()))
+    let results = block_on_async(executor.execute(connection_id, sql.trim(), None))
         .map_err(|e| e.to_string())?;
     format_query_results(&results)
 }

--- a/src-tauri/crates/mas-core/src/query/executor.rs
+++ b/src-tauri/crates/mas-core/src/query/executor.rs
@@ -1,7 +1,7 @@
 use crate::connection::ConnectionManager;
 use crate::error::CoreError;
 use crate::models::{ColumnMeta, QueryResult, SqlValue};
-use sqlx::{Column, Row, TypeInfo};
+use sqlx::{Acquire, Column, Row, TypeInfo};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -19,12 +19,25 @@ impl QueryExecutor {
         &self,
         connection_id: &str,
         sql: &str,
+        database: Option<&str>,
     ) -> Result<Vec<QueryResult>, CoreError> {
         let pool = self.connection_manager.get_pool(connection_id)?;
         let statements = split_statements(sql);
 
         tracing::Span::current().record("statement_count", statements.len());
         tracing::trace!(sql = %sql, "Full SQL input");
+
+        // Acquire a dedicated connection so USE + query share the same session
+        let mut conn = pool.acquire().await.map_err(|e| CoreError::Query(e.to_string()))?;
+
+        if let Some(db) = database {
+            let use_sql = format!("USE `{}`", db);
+            tracing::debug!(database = %db, "Switching database context");
+            sqlx::query(&use_sql)
+                .execute(conn.as_mut())
+                .await
+                .map_err(|e| CoreError::Query(e.to_string()))?;
+        }
 
         let mut results = Vec::new();
 
@@ -48,7 +61,7 @@ impl QueryExecutor {
 
             if is_select {
                 let rows = sqlx::query(trimmed)
-                    .fetch_all(&pool)
+                    .fetch_all(conn.as_mut())
                     .await
                     .map_err(|e| CoreError::Query(e.to_string()))?;
 
@@ -102,7 +115,7 @@ impl QueryExecutor {
                 });
             } else {
                 let result = sqlx::query(trimmed)
-                    .execute(&pool)
+                    .execute(conn.as_mut())
                     .await
                     .map_err(|e| CoreError::Query(e.to_string()))?;
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -123,8 +123,9 @@ pub async fn execute_query(
     state: State<'_, AppState>,
     connection_id: String,
     sql: String,
+    database: Option<String>,
 ) -> Result<Vec<QueryResult>, String> {
-    let results = state.query_executor.execute(&connection_id, &sql).await.map_err(|e| {
+    let results = state.query_executor.execute(&connection_id, &sql, database.as_deref()).await.map_err(|e| {
         tracing::error!(error = %e, "Query execution failed");
         e.to_string()
     })?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,8 +9,46 @@ use std::sync::Arc;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
+/// On macOS GUI apps, the PATH is restricted to /usr/bin:/bin:/usr/sbin:/sbin.
+/// Augment it with directories where tools like the Copilot CLI are commonly installed.
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+fn augment_macos_path() {
+    use std::env;
+
+    let mut extra_paths: Vec<std::path::PathBuf> = vec![
+        "/opt/homebrew/bin".into(),  // Homebrew (Apple Silicon)
+        "/opt/homebrew/sbin".into(),
+        "/usr/local/bin".into(),  // Homebrew (Intel) / npm global default
+        "/usr/local/sbin".into(),
+        "/opt/local/bin".into(), // MacPorts
+    ];
+
+    if let Ok(home) = env::var("HOME") {
+        extra_paths.push(format!("{home}/.npm-global/bin").into());
+        extra_paths.push(format!("{home}/.volta/bin").into());
+    }
+
+    let current_path = env::var("PATH").unwrap_or_default();
+    let existing: Vec<&str> = current_path.split(':').collect();
+
+    let mut new_paths: Vec<String> = extra_paths
+        .iter()
+        .filter(|p| p.exists() && !existing.contains(&p.to_str().unwrap_or("")))
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+
+    if !new_paths.is_empty() {
+        new_paths.extend(existing.iter().map(|s| s.to_string()));
+        env::set_var("PATH", new_paths.join(":"));
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "macos")]
+    augment_macos_path();
+
     let data_dir = dirs::data_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("sqlpilot");
@@ -45,6 +83,9 @@ pub fn run() {
         log_dir = %log_dir.display(),
         "Starting SQLPilot"
     );
+
+    #[cfg(target_os = "macos")]
+    tracing::debug!(path = %std::env::var("PATH").unwrap_or_default(), "PATH after macOS augmentation");
 
     // Keep the non-blocking guard alive for the lifetime of the app
     // by leaking it (it flushes on drop, but we need it alive until exit)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "SQLPilot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.sqlpilot.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/editor/QueryToolbar.tsx
+++ b/src/components/editor/QueryToolbar.tsx
@@ -41,7 +41,7 @@ export function QueryToolbar() {
     if (!selectedConnectionId || isExecuting) return;
     const sql = getCurrentSql();
     if (!sql.trim()) return;
-    executeQuery(selectedConnectionId, sql);
+    executeQuery(selectedConnectionId, sql, activeTab?.database);
   };
 
   const [explainOpen, setExplainOpen] = useState(false);

--- a/src/components/editor/QueryToolbar.tsx
+++ b/src/components/editor/QueryToolbar.tsx
@@ -74,7 +74,7 @@ export function QueryToolbar() {
     if (!selectedConnectionId || isExecuting) return;
     const sql = getCurrentSql();
     if (!sql.trim()) return;
-    executeExplain(selectedConnectionId, sql);
+    executeExplain(selectedConnectionId, sql, activeTab?.database);
     setExplainOpen(false);
   };
 
@@ -82,7 +82,7 @@ export function QueryToolbar() {
     if (!selectedConnectionId || isExecuting) return;
     const sql = getCurrentSql();
     if (!sql.trim()) return;
-    executeExplainAnalyze(selectedConnectionId, sql);
+    executeExplainAnalyze(selectedConnectionId, sql, activeTab?.database);
     setExplainOpen(false);
   };
 

--- a/src/components/editor/QueryToolbar.tsx
+++ b/src/components/editor/QueryToolbar.tsx
@@ -2,9 +2,9 @@ import { useState, useRef, useEffect } from "react";
 import { Play, Square, Database, Search, Replace, Wand2, RefreshCw, ListTree, ChevronDown, Star, MessageSquare, Zap } from "lucide-react";
 import { format } from "sql-formatter";
 import { useEditorStore } from "../../stores/editorStore";
-import { useResultStore } from "../../stores/resultStore";
 import { useConnectionStore } from "../../stores/connectionStore";
 import { useSchemaCache } from "../../hooks/useSchemaCache";
+import { useQueryExecution } from "../../hooks/useQueryExecution";
 import { useAiStore } from "../../stores/aiStore";
 import { SaveFavoriteDialog } from "../favorites/SaveFavoriteDialog";
 
@@ -18,14 +18,10 @@ export function QueryToolbar() {
     return () => window.removeEventListener("open-save-favorite", handler);
   }, []);
 
+  const editorInstance = useEditorStore((s) => s.editorInstance);
   const activeTabId = useEditorStore((s) => s.activeTabId);
   const tabs = useEditorStore((s) => s.tabs);
   const activeTab = tabs.find((t) => t.id === activeTabId);
-  const editorInstance = useEditorStore((s) => s.editorInstance);
-  const executeQuery = useResultStore((s) => s.executeQuery);
-  const executeExplain = useResultStore((s) => s.executeExplain);
-  const executeExplainAnalyze = useResultStore((s) => s.executeExplainAnalyze);
-  const isExecuting = useResultStore((s) => s.isExecuting);
   const selectedConnectionId = useConnectionStore(
     (s) => s.selectedConnectionId,
   );
@@ -33,15 +29,23 @@ export function QueryToolbar() {
   const refreshSchema = useSchemaCache((s) => s.refreshSchema);
   const schemaLoading = useSchemaCache((s) => s.loading);
 
+  const {
+    executeQuery,
+    executeExplain,
+    executeExplainAnalyze,
+    canExecute: hookCanExecute,
+    isExecuting,
+  } = useQueryExecution();
+
   const activeConnection = activeConnections.find(
     (c) => c.id === selectedConnectionId,
   );
 
   const handleExecute = () => {
-    if (!selectedConnectionId || isExecuting) return;
+    if (!hookCanExecute) return;
     const sql = getCurrentSql();
     if (!sql.trim()) return;
-    executeQuery(selectedConnectionId, sql, activeTab?.database);
+    executeQuery(sql);
   };
 
   const [explainOpen, setExplainOpen] = useState(false);
@@ -71,18 +75,18 @@ export function QueryToolbar() {
   };
 
   const handleExplain = () => {
-    if (!selectedConnectionId || isExecuting) return;
+    if (!hookCanExecute) return;
     const sql = getCurrentSql();
     if (!sql.trim()) return;
-    executeExplain(selectedConnectionId, sql, activeTab?.database);
+    executeExplain(sql);
     setExplainOpen(false);
   };
 
   const handleExplainAnalyze = () => {
-    if (!selectedConnectionId || isExecuting) return;
+    if (!hookCanExecute) return;
     const sql = getCurrentSql();
     if (!sql.trim()) return;
-    executeExplainAnalyze(selectedConnectionId, sql, activeTab?.database);
+    executeExplainAnalyze(sql);
     setExplainOpen(false);
   };
 
@@ -113,7 +117,7 @@ export function QueryToolbar() {
   };
 
   const canExecute =
-    !!activeTab?.content?.trim() && !!selectedConnectionId && !isExecuting;
+    !!activeTab?.content?.trim() && hookCanExecute;
 
   const toolbarBtnClass =
     "flex items-center gap-1 rounded px-1.5 py-1 text-xs text-[var(--color-text-muted)] hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed";

--- a/src/components/editor/SQLEditor.tsx
+++ b/src/components/editor/SQLEditor.tsx
@@ -42,8 +42,10 @@ export function SQLEditor() {
         connectionId: schemaCache.connectionId,
         databases: schemaCache.databases,
         tables: schemaCache.tables,
+        views: schemaCache.views,
         columns: schemaCache.columns,
         fetchTables: schemaCache.fetchTables,
+        fetchViews: schemaCache.fetchViews,
         fetchColumns: schemaCache.fetchColumns,
       }),
     );
@@ -57,6 +59,7 @@ export function SQLEditor() {
     schemaCache.connectionId,
     schemaCache.databases,
     schemaCache.tables,
+    schemaCache.views,
     schemaCache.columns,
   ]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/layout/MainPanel.tsx
+++ b/src/components/layout/MainPanel.tsx
@@ -103,6 +103,7 @@ function ResultsPanel({
   setShowExplain: (v: boolean) => void;
 }) {
   const [activeTab, setActiveTab] = useState<"results" | "explain">("results");
+  const results = useResultStore((s) => s.results);
 
   // Auto-switch to explain tab whenever a new explain result arrives
   useEffect(() => {
@@ -110,6 +111,13 @@ function ResultsPanel({
       setActiveTab("explain");
     }
   }, [explainResult]);
+
+  // Switch back to results tab when a new query result arrives
+  useEffect(() => {
+    if (results.length > 0) {
+      setActiveTab("results");
+    }
+  }, [results]);
 
   const hasExplain = showExplain && !!explainResult;
 

--- a/src/components/layout/MainPanel.tsx
+++ b/src/components/layout/MainPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useEffect } from "react";
 import { PanelGroup, Panel, PanelResizeHandle } from "react-resizable-panels";
 import { SQLEditor } from "../editor/SQLEditor";
 import { EditorTabs } from "../editor/EditorTabs";
@@ -102,18 +102,14 @@ function ResultsPanel({
   explainResult: unknown;
   setShowExplain: (v: boolean) => void;
 }) {
-  const [activeTab, setActiveTab] = useState<"results" | "explain">(
-    showExplain && explainResult ? "explain" : "results",
-  );
+  const [activeTab, setActiveTab] = useState<"results" | "explain">("results");
 
-  // Switch to explain tab when new explain result arrives
-  const prevExplainRef = useRef(explainResult);
-  if (explainResult && explainResult !== prevExplainRef.current) {
-    prevExplainRef.current = explainResult;
-    if (activeTab !== "explain") {
+  // Auto-switch to explain tab whenever a new explain result arrives
+  useEffect(() => {
+    if (explainResult) {
       setActiveTab("explain");
     }
-  }
+  }, [explainResult]);
 
   const hasExplain = showExplain && !!explainResult;
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -370,14 +370,14 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
   const handleTableClick = (dbName: string, tableName: string) =>
     makeClickHandler(
       `${dbName}.${tableName}`,
-      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${tableName}\` LIMIT 100`),
+      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${tableName}\` LIMIT 100`, dbName),
       () => insertNameAtCursor(tableName),
     );
 
   const handleViewClick = (dbName: string, viewName: string) =>
     makeClickHandler(
       `${dbName}.${viewName}`,
-      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${viewName}\` LIMIT 100`),
+      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${viewName}\` LIMIT 100`, dbName),
       () => insertNameAtCursor(viewName),
     );
 
@@ -590,7 +590,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                             label: "Select Top 100 Rows",
                             icon: <Search className="h-3.5 w-3.5" />,
                             onClick: () => {
-                              executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${t.name}\` LIMIT 100`);
+                              executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${t.name}\` LIMIT 100`, db.name);
                             },
                           },
                           {
@@ -694,7 +694,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                           label: "Select Top 100 Rows",
                           icon: <Search className="h-3.5 w-3.5" />,
                           onClick: () => {
-                            executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${v.name}\` LIMIT 100`);
+                            executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${v.name}\` LIMIT 100`, db.name);
                           },
                         },
                         {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Plus,
   Database,
@@ -13,6 +13,7 @@ import {
   RefreshCw,
   Copy,
   Search,
+  X,
   Columns3,
   History,
   Cog,
@@ -33,6 +34,7 @@ import { QueryFavorites } from "../favorites/QueryFavorites";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/tauri-api";
 import { useContextMenu } from "../../hooks/useContextMenu";
+import { useClickHandler } from "../../hooks/useClickHandler";
 import type { DatabaseInfo, TableInfo, ViewInfo, RoutineInfo, TriggerInfo } from "../../types";
 
 export function Sidebar() {
@@ -244,17 +246,87 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
   const [views, setViews] = useState<Record<string, ViewInfo[]>>({});
   const [routines, setRoutines] = useState<Record<string, RoutineInfo[]>>({});
   const [triggers, setTriggers] = useState<Record<string, TriggerInfo[]>>({});
+  const [filterText, setFilterText] = useState("");
+  const filterInputRef = useRef<HTMLInputElement>(null);
   const addTab = useEditorStore((s) => s.addTab);
   const addStructureTab = useEditorStore((s) => s.addStructureTab);
   const addRoutineTab = useEditorStore((s) => s.addRoutineTab);
   const addDesignerTab = useEditorStore((s) => s.addDesignerTab);
   const updateTabContent = useEditorStore((s) => s.updateTabContent);
+  const setTabConnection = useEditorStore((s) => s.setTabConnection);
+  const activeTabId = useEditorStore((s) => s.activeTabId);
+  const tabs = useEditorStore((s) => s.tabs);
   const executeQuery = useResultStore((s) => s.executeQuery);
   const { contextMenu, showContextMenu } = useContextMenu();
+
+  // Derive the selected database from the active tab
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+  const selectedDb = activeTab?.database ?? null;
+
+  // Set the active tab's database context to the given DB
+  const selectDatabase = (dbName: string) => {
+    if (!activeTabId) return;
+    setTabConnection(activeTabId, connectionId, dbName);
+  };
+
+  // Tracks pending single-click timers keyed by "db.name"
+  const makeClickHandler = useClickHandler();
+
+  // Insert a backtick-quoted name at the active editor cursor
+  const insertNameAtCursor = (name: string) => {
+    const editor = useEditorStore.getState().editorInstance;
+    if (!editor) return;
+    const selection = editor.getSelection();
+    if (!selection) return;
+    editor.executeEdits("insert-name", [{ range: selection, text: `\`${name}\`` }]);
+    editor.focus();
+  };
 
   useEffect(() => {
     api.getDatabases(connectionId).then(setDatabases).catch(console.error);
   }, [connectionId]);
+
+  // Ctrl+Shift+F focuses the filter input
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === "F") {
+        e.preventDefault();
+        filterInputRef.current?.focus();
+        filterInputRef.current?.select();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  // When filter becomes active, eagerly fetch all unloaded DB data so search is complete
+  const filterActive = filterText.trim().length > 0;
+  useEffect(() => {
+    if (!filterActive || databases.length === 0) return;
+    databases.forEach(async (db) => {
+      try {
+        if (!tables[db.name]) {
+          const t = await api.getTables(connectionId, db.name);
+          setTables((prev) => ({ ...prev, [db.name]: t }));
+        }
+        if (!views[db.name]) {
+          const v = await api.getViews(connectionId, db.name);
+          setViews((prev) => ({ ...prev, [db.name]: v }));
+        }
+        if (!routines[db.name]) {
+          const r = await api.getRoutines(connectionId, db.name);
+          setRoutines((prev) => ({ ...prev, [db.name]: r }));
+        }
+        if (!triggers[db.name]) {
+          const t = await api.getTriggers(connectionId, db.name);
+          setTriggers((prev) => ({ ...prev, [db.name]: t }));
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterActive, databases]);
 
   const toggleDb = async (dbName: string) => {
     const isExpanded = expanded[dbName];
@@ -293,21 +365,21 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
     }
   };
 
-  const openTableQuery = (dbName: string, tableName: string) => {
-    const tabId = addTab(connectionId, dbName);
-    updateTabContent(
-      tabId,
-      `SELECT * FROM \`${dbName}\`.\`${tableName}\` LIMIT 100;`,
+  // Single click: run SELECT inline without touching the editor tab
+  // Double click (within 250ms): insert table name at cursor instead
+  const handleTableClick = (dbName: string, tableName: string) =>
+    makeClickHandler(
+      `${dbName}.${tableName}`,
+      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${tableName}\` LIMIT 100`),
+      () => insertNameAtCursor(tableName),
     );
-  };
 
-  const openViewQuery = (dbName: string, viewName: string) => {
-    const tabId = addTab(connectionId, dbName);
-    updateTabContent(
-      tabId,
-      `SELECT * FROM \`${dbName}\`.\`${viewName}\` LIMIT 100;`,
+  const handleViewClick = (dbName: string, viewName: string) =>
+    makeClickHandler(
+      `${dbName}.${viewName}`,
+      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${viewName}\` LIMIT 100`),
+      () => insertNameAtCursor(viewName),
     );
-  };
 
   const openDdlTab = (dbName: string, _objectName: string, ddlQuery: string) => {
     const tabId = addTab(connectionId, dbName);
@@ -344,12 +416,89 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
   const isFolderExpanded = (dbName: string, folder: string) =>
     !!expandedFolders[folderKey(dbName, folder)];
 
+  // --- Filter helpers ---
+  const filterLower = filterText.toLowerCase().trim();
+  const isFiltering = filterLower.length > 0;
+  const matchItem = (name: string) => name.toLowerCase().includes(filterLower);
+
+  const filteredTables = (dbName: string) => {
+    const all = tables[dbName]?.filter((t) => t.table_type !== "VIEW") ?? [];
+    return isFiltering ? all.filter((t) => matchItem(t.name)) : all;
+  };
+  const filteredViews = (dbName: string) => {
+    const all = views[dbName] ?? [];
+    return isFiltering ? all.filter((v) => matchItem(v.name)) : all;
+  };
+  const filteredProcedures = (dbName: string) => {
+    const all = routines[dbName]?.filter((r) => r.routine_type === "PROCEDURE") ?? [];
+    return isFiltering ? all.filter((r) => matchItem(r.name)) : all;
+  };
+  const filteredFunctions = (dbName: string) => {
+    const all = routines[dbName]?.filter((r) => r.routine_type === "FUNCTION") ?? [];
+    return isFiltering ? all.filter((r) => matchItem(r.name)) : all;
+  };
+  const filteredTriggers = (dbName: string) => {
+    const all = triggers[dbName] ?? [];
+    return isFiltering ? all.filter((t) => matchItem(t.name)) : all;
+  };
+
+  const dbHasMatches = (dbName: string) =>
+    filteredTables(dbName).length > 0 ||
+    filteredViews(dbName).length > 0 ||
+    filteredProcedures(dbName).length > 0 ||
+    filteredFunctions(dbName).length > 0 ||
+    filteredTriggers(dbName).length > 0;
+
+  // Show all DBs while filtering; hide only those whose data IS loaded and has no matches
+  const isDbVisible = (dbName: string) =>
+    !isFiltering || tables[dbName] === undefined || dbHasMatches(dbName);
+
+  // Auto-expand when matches found; also respect manual toggles while filtering
+  const isDbExpanded = (dbName: string) =>
+    isFiltering
+      ? !!expanded[dbName] || (tables[dbName] !== undefined && dbHasMatches(dbName))
+      : !!expanded[dbName];
+
+  // When filtering, hide empty folders and auto-expand folders with matches;
+  // also respect manual folder toggles
+  const isFolderVisible = (count: number) =>
+    !isFiltering || count > 0;
+  const isFolderExpandedFiltered = (dbName: string, folder: string, filteredCount: number) =>
+    isFiltering
+      ? isFolderExpanded(dbName, folder) || filteredCount > 0
+      : isFolderExpanded(dbName, folder);
+
   return (
     <div className="ml-4 border-l border-[var(--color-border)] pl-1">
-      {databases.map((db) => (
+      {/* Filter input */}
+      <div className="relative mb-1 mt-0.5 px-1">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3 w-3 -translate-y-1/2 text-[var(--color-text-muted)]" />
+        <input
+          ref={filterInputRef}
+          type="text"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          onKeyDown={(e) => e.key === "Escape" && setFilterText("")}
+          placeholder="Filter (Ctrl+Shift+F)"
+          className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg-secondary)] py-0.5 pl-6 pr-6 text-[11px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:border-brand-500 focus:outline-none"
+        />
+        {filterText && (
+          <button
+            onClick={() => setFilterText("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+      {databases.filter((db) => isDbVisible(db.name)).map((db) => (
         <div key={db.name}>
           <button
-            onClick={() => toggleDb(db.name)}
+            onClick={makeClickHandler(
+              `db:${db.name}`,
+              () => toggleDb(db.name),
+              () => selectDatabase(db.name),
+            )}
             onContextMenu={(e) => {
               showContextMenu(e, [
                 {
@@ -390,23 +539,32 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                 },
               ]);
             }}
-            className="flex w-full items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
+            className={cn(
+              "flex w-full items-center gap-1 rounded px-1.5 py-0.5 text-[11px] hover:text-[var(--color-text-secondary)]",
+              selectedDb === db.name
+                ? "font-semibold text-[var(--color-accent)] hover:text-[var(--color-accent)]"
+                : "text-[var(--color-text-muted)]",
+            )}
           >
-            {expanded[db.name] ? (
+            {isDbExpanded(db.name) ? (
               <ChevronDown className="h-3 w-3" />
             ) : (
               <ChevronRight className="h-3 w-3" />
             )}
-            <Database className="h-3 w-3" />
+            <Database className={cn("h-3 w-3", selectedDb === db.name && "text-[var(--color-accent)]")} />
             <span>{db.name}</span>
+            {selectedDb === db.name && (
+              <span className="ml-auto text-[9px] text-[var(--color-accent)] opacity-75">●</span>
+            )}
           </button>
-          {expanded[db.name] && (
+          {isDbExpanded(db.name) && (
             <div className="ml-3">
               {/* Tables folder */}
+              {isFolderVisible(filteredTables(db.name).length) && (
               <FolderNode
                 label="Tables"
                 icon={<Table2 className="h-3 w-3" />}
-                isExpanded={isFolderExpanded(db.name, "tables")}
+                isExpanded={isFolderExpandedFiltered(db.name, "tables", filteredTables(db.name).length)}
                 onToggle={() => toggleFolder(db.name, "tables")}
                 onContextMenu={(e) => {
                   showContextMenu(e, [
@@ -419,23 +577,20 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                 }}
                 count={tables[db.name]?.filter((t) => t.table_type !== "VIEW").length}
               >
-                {tables[db.name]?.filter((t) => t.table_type !== "VIEW").map((t) => (
+                {filteredTables(db.name).map((t) => (
                   <div
                     key={t.name}
                     className="group/table flex items-center rounded hover:bg-[var(--color-bg-tertiary)]"
                   >
                     <button
-                      onClick={() => openTableQuery(db.name, t.name)}
+                      onClick={handleTableClick(db.name, t.name)}
                       onContextMenu={(e) => {
                         showContextMenu(e, [
                           {
                             label: "Select Top 100 Rows",
                             icon: <Search className="h-3.5 w-3.5" />,
                             onClick: () => {
-                              const sql = `SELECT * FROM \`${db.name}\`.\`${t.name}\` LIMIT 100`;
-                              const tabId = addTab(connectionId, db.name);
-                              updateTabContent(tabId, sql);
-                              executeQuery(connectionId, sql);
+                              executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${t.name}\` LIMIT 100`);
                             },
                           },
                           {
@@ -509,12 +664,14 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                   </div>
                 ))}
               </FolderNode>
+              )}
 
               {/* Views folder */}
+              {isFolderVisible(filteredViews(db.name).length) && (
               <FolderNode
                 label="Views"
                 icon={<Eye className="h-3 w-3" />}
-                isExpanded={isFolderExpanded(db.name, "views")}
+                isExpanded={isFolderExpandedFiltered(db.name, "views", filteredViews(db.name).length)}
                 onToggle={() => toggleFolder(db.name, "views")}
                 onContextMenu={(e) => {
                   showContextMenu(e, [
@@ -527,20 +684,17 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                 }}
                 count={views[db.name]?.length}
               >
-                {views[db.name]?.map((v) => (
+                {filteredViews(db.name).map((v) => (
                   <button
                     key={v.name}
-                    onClick={() => openViewQuery(db.name, v.name)}
+                    onClick={handleViewClick(db.name, v.name)}
                     onContextMenu={(e) => {
                       showContextMenu(e, [
                         {
                           label: "Select Top 100 Rows",
                           icon: <Search className="h-3.5 w-3.5" />,
                           onClick: () => {
-                            const sql = `SELECT * FROM \`${db.name}\`.\`${v.name}\` LIMIT 100`;
-                            const tabId = addTab(connectionId, db.name);
-                            updateTabContent(tabId, sql);
-                            executeQuery(connectionId, sql);
+                            executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${v.name}\` LIMIT 100`);
                           },
                         },
                         {
@@ -579,12 +733,14 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                   </button>
                 ))}
               </FolderNode>
+              )}
 
               {/* Procedures folder */}
+              {isFolderVisible(filteredProcedures(db.name).length) && (
               <FolderNode
                 label="Procedures"
                 icon={<Cog className="h-3 w-3" />}
-                isExpanded={isFolderExpanded(db.name, "procedures")}
+                isExpanded={isFolderExpandedFiltered(db.name, "procedures", filteredProcedures(db.name).length)}
                 onToggle={() => toggleFolder(db.name, "procedures")}
                 onContextMenu={(e) => {
                   showContextMenu(e, [
@@ -597,9 +753,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                 }}
                 count={routines[db.name]?.filter((r) => r.routine_type === "PROCEDURE").length}
               >
-                {routines[db.name]
-                  ?.filter((r) => r.routine_type === "PROCEDURE")
-                  .map((r) => (
+                {filteredProcedures(db.name).map((r) => (
                     <button
                       key={r.name}
                       onClick={() =>
@@ -652,12 +806,14 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                     </button>
                   ))}
               </FolderNode>
+              )}
 
               {/* Functions folder */}
+              {isFolderVisible(filteredFunctions(db.name).length) && (
               <FolderNode
                 label="Functions"
                 icon={<FunctionSquare className="h-3 w-3" />}
-                isExpanded={isFolderExpanded(db.name, "functions")}
+                isExpanded={isFolderExpandedFiltered(db.name, "functions", filteredFunctions(db.name).length)}
                 onToggle={() => toggleFolder(db.name, "functions")}
                 onContextMenu={(e) => {
                   showContextMenu(e, [
@@ -670,9 +826,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                 }}
                 count={routines[db.name]?.filter((r) => r.routine_type === "FUNCTION").length}
               >
-                {routines[db.name]
-                  ?.filter((r) => r.routine_type === "FUNCTION")
-                  .map((r) => (
+                {filteredFunctions(db.name).map((r) => (
                     <button
                       key={r.name}
                       onClick={() =>
@@ -725,12 +879,14 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                     </button>
                   ))}
               </FolderNode>
+              )}
 
               {/* Triggers folder */}
+              {isFolderVisible(filteredTriggers(db.name).length) && (
               <FolderNode
                 label="Triggers"
                 icon={<Zap className="h-3 w-3" />}
-                isExpanded={isFolderExpanded(db.name, "triggers")}
+                isExpanded={isFolderExpandedFiltered(db.name, "triggers", filteredTriggers(db.name).length)}
                 onToggle={() => toggleFolder(db.name, "triggers")}
                 onContextMenu={(e) => {
                   showContextMenu(e, [
@@ -743,7 +899,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                 }}
                 count={triggers[db.name]?.length}
               >
-                {triggers[db.name]?.map((t) => (
+                {filteredTriggers(db.name).map((t) => (
                   <button
                     key={t.name}
                     onClick={() =>
@@ -790,6 +946,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                   </button>
                 ))}
               </FolderNode>
+              )}
             </div>
           )}
         </div>

--- a/src/hooks/__tests__/useQueryExecution.test.ts
+++ b/src/hooks/__tests__/useQueryExecution.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useQueryExecution } from "../useQueryExecution";
+import { useConnectionStore } from "../../stores/connectionStore";
+import { useEditorStore } from "../../stores/editorStore";
+import { useResultStore } from "../../stores/resultStore";
+
+// Mock the Tauri API so store actions that call invoke don't fail
+vi.mock("../../lib/tauri-api", () => ({
+  api: {
+    executeQuery: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+const mockExecuteQuery = vi.fn().mockResolvedValue(undefined);
+const mockExecuteExplain = vi.fn().mockResolvedValue(undefined);
+const mockExecuteExplainAnalyze = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Reset stores to clean state
+  useConnectionStore.setState({
+    selectedConnectionId: null,
+    activeConnections: [],
+    profiles: [],
+  } as Parameters<typeof useConnectionStore.setState>[0]);
+
+  useEditorStore.setState({ tabs: [], activeTabId: null });
+
+  useResultStore.setState({
+    isExecuting: false,
+    error: null,
+    results: [],
+    executeQuery: mockExecuteQuery,
+    executeExplain: mockExecuteExplain,
+    executeExplainAnalyze: mockExecuteExplainAnalyze,
+  } as Parameters<typeof useResultStore.setState>[0]);
+});
+
+describe("useQueryExecution", () => {
+  it("canExecute is false when no connection is selected", () => {
+    const { result } = renderHook(() => useQueryExecution());
+    expect(result.current.canExecute).toBe(false);
+  });
+
+  it("canExecute is false when a query is executing", () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-1" } as Parameters<typeof useConnectionStore.setState>[0]);
+    useResultStore.setState({ isExecuting: true } as Parameters<typeof useResultStore.setState>[0]);
+    const { result } = renderHook(() => useQueryExecution());
+    expect(result.current.canExecute).toBe(false);
+  });
+
+  it("canExecute is true when connection is set and not executing", () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-1" } as Parameters<typeof useConnectionStore.setState>[0]);
+    const { result } = renderHook(() => useQueryExecution());
+    expect(result.current.canExecute).toBe(true);
+  });
+
+  it("exposes the selected connectionId and active tab database", () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-1" } as Parameters<typeof useConnectionStore.setState>[0]);
+    const tabId = useEditorStore.getState().addTab("conn-1", "my_db");
+    useEditorStore.getState().setTabConnection(tabId, "conn-1", "my_db");
+
+    const { result } = renderHook(() => useQueryExecution());
+    expect(result.current.connectionId).toBe("conn-1");
+    expect(result.current.database).toBe("my_db");
+  });
+
+  it("executeQuery passes connectionId and database from active tab to the store action", async () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-1" } as Parameters<typeof useConnectionStore.setState>[0]);
+    const tabId = useEditorStore.getState().addTab("conn-1", "my_db");
+    useEditorStore.getState().setTabConnection(tabId, "conn-1", "my_db");
+
+    const { result } = renderHook(() => useQueryExecution());
+    await act(() => result.current.executeQuery("SELECT 1"));
+
+    expect(mockExecuteQuery).toHaveBeenCalledWith("conn-1", "SELECT 1", "my_db");
+  });
+
+  it("executeQuery uses undefined database when no tab database is set", async () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-1" } as Parameters<typeof useConnectionStore.setState>[0]);
+    useEditorStore.getState().addTab("conn-1");
+
+    const { result } = renderHook(() => useQueryExecution());
+    await act(() => result.current.executeQuery("SELECT 1"));
+
+    expect(mockExecuteQuery).toHaveBeenCalledWith("conn-1", "SELECT 1", undefined);
+  });
+
+  it("executeQuery does nothing when no connection is selected", async () => {
+    const { result } = renderHook(() => useQueryExecution());
+    await act(() => result.current.executeQuery("SELECT 1"));
+    expect(mockExecuteQuery).not.toHaveBeenCalled();
+  });
+
+  it("executeExplain passes connectionId and database from active tab", async () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-2" } as Parameters<typeof useConnectionStore.setState>[0]);
+    const tabId = useEditorStore.getState().addTab("conn-2", "schema_x");
+    useEditorStore.getState().setTabConnection(tabId, "conn-2", "schema_x");
+
+    const { result } = renderHook(() => useQueryExecution());
+    await act(() => result.current.executeExplain("SELECT * FROM t"));
+
+    expect(mockExecuteExplain).toHaveBeenCalledWith("conn-2", "SELECT * FROM t", "schema_x");
+  });
+
+  it("executeExplainAnalyze passes connectionId and database from active tab", async () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-3" } as Parameters<typeof useConnectionStore.setState>[0]);
+    const tabId = useEditorStore.getState().addTab("conn-3", "db_y");
+    useEditorStore.getState().setTabConnection(tabId, "conn-3", "db_y");
+
+    const { result } = renderHook(() => useQueryExecution());
+    await act(() => result.current.executeExplainAnalyze("SELECT * FROM t"));
+
+    expect(mockExecuteExplainAnalyze).toHaveBeenCalledWith("conn-3", "SELECT * FROM t", "db_y");
+  });
+
+  it("database reflects the active tab after setTabConnection", () => {
+    useConnectionStore.setState({ selectedConnectionId: "conn-1" } as Parameters<typeof useConnectionStore.setState>[0]);
+    const tabId = useEditorStore.getState().addTab("conn-1");
+
+    const { result, rerender } = renderHook(() => useQueryExecution());
+    expect(result.current.database).toBeUndefined();
+
+    act(() => {
+      useEditorStore.getState().setTabConnection(tabId, "conn-1", "new_db");
+    });
+    rerender();
+
+    expect(result.current.database).toBe("new_db");
+  });
+});

--- a/src/hooks/useClickHandler.ts
+++ b/src/hooks/useClickHandler.ts
@@ -1,0 +1,38 @@
+import { useRef } from "react";
+
+const DOUBLE_CLICK_DELAY_MS = 250;
+
+/**
+ * Returns a `makeClickHandler` factory bound to a shared timer map.
+ * Each call to `makeClickHandler(key, onSingle, onDouble)` returns an onClick
+ * handler that distinguishes single clicks from double clicks:
+ *   - First click arms a timer; if no second click arrives within the delay,
+ *     `onSingle` fires.
+ *   - Second click within the delay cancels the timer and fires `onDouble`.
+ */
+export function useClickHandler() {
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const makeClickHandler = (
+    key: string,
+    onSingle: () => void,
+    onDouble: () => void,
+  ) => {
+    return () => {
+      const pending = timers.current.get(key);
+      if (pending) {
+        clearTimeout(pending);
+        timers.current.delete(key);
+        onDouble();
+      } else {
+        const timer = setTimeout(() => {
+          timers.current.delete(key);
+          onSingle();
+        }, DOUBLE_CLICK_DELAY_MS);
+        timers.current.set(key, timer);
+      }
+    };
+  };
+
+  return makeClickHandler;
+}

--- a/src/hooks/useQueryExecution.ts
+++ b/src/hooks/useQueryExecution.ts
@@ -1,0 +1,64 @@
+import { useCallback } from "react";
+import { useConnectionStore } from "../stores/connectionStore";
+import { useEditorStore } from "../stores/editorStore";
+import { useResultStore } from "../stores/resultStore";
+
+/**
+ * Centralizes query execution context so callers never have to thread
+ * connectionId/database manually. Reads both from the active tab and
+ * the selected connection, then exposes pre-bound execute/explain helpers.
+ */
+export function useQueryExecution() {
+  const selectedConnectionId = useConnectionStore(
+    (s) => s.selectedConnectionId,
+  );
+  const activeTabId = useEditorStore((s) => s.activeTabId);
+  const tabs = useEditorStore((s) => s.tabs);
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+
+  const storeExecuteQuery = useResultStore((s) => s.executeQuery);
+  const storeExecuteExplain = useResultStore((s) => s.executeExplain);
+  const storeExecuteExplainAnalyze = useResultStore(
+    (s) => s.executeExplainAnalyze,
+  );
+  const isExecuting = useResultStore((s) => s.isExecuting);
+
+  const connectionId = selectedConnectionId ?? undefined;
+  const database = activeTab?.database;
+
+  const executeQuery = useCallback(
+    (sql: string) => {
+      if (!connectionId) return Promise.resolve();
+      return storeExecuteQuery(connectionId, sql, database);
+    },
+    [connectionId, database, storeExecuteQuery],
+  );
+
+  const executeExplain = useCallback(
+    (sql: string) => {
+      if (!connectionId) return Promise.resolve();
+      return storeExecuteExplain(connectionId, sql, database);
+    },
+    [connectionId, database, storeExecuteExplain],
+  );
+
+  const executeExplainAnalyze = useCallback(
+    (sql: string) => {
+      if (!connectionId) return Promise.resolve();
+      return storeExecuteExplainAnalyze(connectionId, sql, database);
+    },
+    [connectionId, database, storeExecuteExplainAnalyze],
+  );
+
+  const canExecute = !!connectionId && !isExecuting;
+
+  return {
+    executeQuery,
+    executeExplain,
+    executeExplainAnalyze,
+    canExecute,
+    isExecuting,
+    connectionId,
+    database,
+  };
+}

--- a/src/lib/schema-completion-provider.ts
+++ b/src/lib/schema-completion-provider.ts
@@ -5,8 +5,10 @@ export interface SchemaData {
   connectionId: string | null;
   databases: string[];
   tables: Map<string, string[]>;
+  views: Map<string, string[]>;
   columns: Map<string, ColumnInfo[]>;
   fetchTables: (connId: string, db: string) => Promise<string[]>;
+  fetchViews: (connId: string, db: string) => Promise<string[]>;
   fetchColumns: (
     connId: string,
     db: string,
@@ -165,11 +167,29 @@ const COLUMN_CONTEXTS =
 const DATABASE_CONTEXTS = /\b(?:USE|DATABASE)\s+$/i;
 
 function detectContext(textBeforeCursor: string): Context {
-  const trimmed = textBeforeCursor.trimEnd();
-  if (DATABASE_CONTEXTS.test(trimmed)) return "database";
-  if (TABLE_CONTEXTS.test(trimmed)) return "table";
-  if (COLUMN_CONTEXTS.test(trimmed)) return "column";
+  // Do NOT trim — the regexes rely on trailing whitespace to confirm the
+  // keyword is complete and the user is starting a new token.
+  if (DATABASE_CONTEXTS.test(textBeforeCursor)) return "database";
+  if (TABLE_CONTEXTS.test(textBeforeCursor)) return "table";
+  if (COLUMN_CONTEXTS.test(textBeforeCursor)) return "column";
   return "general";
+}
+
+/** Extract table names referenced after FROM / JOIN in a SQL snippet. */
+function parseFromTables(sql: string): string[] {
+  const found: string[] = [];
+  // Match FROM/JOIN followed by an optional db. prefix then the table name.
+  // Handles back-tick quoting and aliases.
+  const re =
+    /\b(?:FROM|JOIN)\s+(?:`?\w+`?\.)?`?(\w+)`?(?:\s+(?:AS\s+)?`?\w+`?)?/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sql)) !== null) {
+    const name = m[1];
+    if (!MYSQL_KEYWORDS.includes(name.toUpperCase())) {
+      found.push(name);
+    }
+  }
+  return [...new Set(found)];
 }
 
 function findDotPrefix(
@@ -285,12 +305,41 @@ export function createCompletionProvider(
         }
       }
 
-      // Table suggestions
+      // Table/view suggestions — only for table context (after FROM/JOIN/etc.)
+      if (connectionId && context === "table") {
+        for (const [db, dbTables] of tables.entries()) {
+          for (const t of dbTables) {
+            suggestions.push({
+              label: t,
+              kind: monaco.languages.CompletionItemKind.Class,
+              insertText: t,
+              range,
+              sortText: "0" + t,
+              detail: `Table (${db})`,
+            });
+          }
+        }
+        for (const [db, dbViews] of schemaData.views.entries()) {
+          for (const v of dbViews) {
+            suggestions.push({
+              label: v,
+              kind: monaco.languages.CompletionItemKind.Interface,
+              insertText: v,
+              range,
+              sortText: "0" + v,
+              detail: `View (${db})`,
+            });
+          }
+        }
+        return { suggestions };
+      }
+
+      // Table suggestions for general/column contexts (lower priority)
       if (
         connectionId &&
-        (context === "table" || context === "column" || context === "general")
+        (context === "column" || context === "general")
       ) {
-        const tablePriority = context === "table" ? "0" : "2";
+        const tablePriority = context === "general" ? "2" : "3";
         for (const [db, dbTables] of tables.entries()) {
           for (const t of dbTables) {
             suggestions.push({
@@ -305,23 +354,54 @@ export function createCompletionProvider(
         }
       }
 
-      // Column suggestions
-      if (
-        connectionId &&
-        (context === "column" || context === "general")
-      ) {
+      // Column suggestions — prefer columns from tables referenced in the FROM clause
+      if (connectionId && (context === "column" || context === "general")) {
         const colPriority = context === "column" ? "0" : "4";
-        for (const [key, cols] of columns.entries()) {
-          for (const col of cols) {
-            suggestions.push({
-              label: col.name,
-              kind: monaco.languages.CompletionItemKind.Field,
-              insertText: col.name,
-              range,
-              detail: `${col.column_type} (${key})`,
-              documentation: buildColumnDoc(col),
-              sortText: colPriority + col.name,
-            });
+        const fullSql = model.getValue();
+        const fromTables = parseFromTables(fullSql);
+
+        if (fromTables.length > 0) {
+          // Fetch and suggest only columns for tables present in the FROM clause
+          for (const tableName of fromTables) {
+            for (const [db, dbTables] of tables.entries()) {
+              const match = dbTables.find(
+                (t) => t.toLowerCase() === tableName.toLowerCase(),
+              );
+              if (match) {
+                const key = `${db}.${match}`;
+                const cachedCols = columns.get(key);
+                const cols = cachedCols
+                  ? cachedCols
+                  : await schemaData.fetchColumns(connectionId, db, match);
+                for (const col of cols) {
+                  suggestions.push({
+                    label: col.name,
+                    kind: monaco.languages.CompletionItemKind.Field,
+                    insertText: col.name,
+                    range,
+                    detail: `${col.column_type} (${key})`,
+                    documentation: buildColumnDoc(col),
+                    sortText: colPriority + col.name,
+                  });
+                }
+                break; // found db for this table
+              }
+            }
+          }
+        } else {
+          // Fall back to all cached columns when no FROM tables are identifiable
+          for (const [key, cols] of columns.entries()) {
+            for (const col of cols) {
+              suggestions.push({
+                label: col.name,
+                kind: monaco.languages.CompletionItemKind.Field,
+                insertText: col.name,
+                range,
+                detail: `${col.column_type} (${key})`,
+                documentation: buildColumnDoc(col),
+                sortText: colPriority + col.name,
+              });
+            }
           }
         }
       }
@@ -368,5 +448,5 @@ function buildColumnDoc(col: ColumnInfo): string {
   return parts.join(" | ");
 }
 
-export { MYSQL_KEYWORDS, MYSQL_FUNCTIONS, detectContext, findDotPrefix };
+export { MYSQL_KEYWORDS, MYSQL_FUNCTIONS, detectContext, findDotPrefix, parseFromTables };
 export type { Context };

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -57,8 +57,8 @@ export const api = {
     tauriInvoke<ConnectionInfo[]>("list_connections"),
 
   // Queries
-  executeQuery: (connectionId: string, sql: string) =>
-    tauriInvoke<QueryResult[]>("execute_query", { connectionId, sql }),
+  executeQuery: (connectionId: string, sql: string, database?: string) =>
+    tauriInvoke<QueryResult[]>("execute_query", { connectionId, sql, database }),
 
   // Schema
   getDatabases: (connectionId: string) =>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,18 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/globals.css";
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+
+(self as typeof globalThis & { MonacoEnvironment: unknown }).MonacoEnvironment =
+  {
+    getWorker() {
+      return new editorWorker();
+    },
+  };
+
+loader.config({ monaco });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/stores/resultStore.ts
+++ b/src/stores/resultStore.ts
@@ -27,8 +27,8 @@ interface ResultState {
   confirmDialog: ConfirmDialogState | null;
 
   executeQuery: (connectionId: string, sql: string, database?: string) => Promise<void>;
-  executeExplain: (connectionId: string, sql: string) => Promise<void>;
-  executeExplainAnalyze: (connectionId: string, sql: string) => Promise<void>;
+  executeExplain: (connectionId: string, sql: string, database?: string) => Promise<void>;
+  executeExplainAnalyze: (connectionId: string, sql: string, database?: string) => Promise<void>;
   setActiveResult: (index: number) => void;
   setShowExplain: (show: boolean) => void;
   clearResults: () => void;
@@ -89,12 +89,13 @@ export const useResultStore = create<ResultState>((set, get) => ({
     }),
   clearError: () => set({ error: null }),
 
-  executeExplain: async (connectionId, sql) => {
+  executeExplain: async (connectionId, sql, database) => {
     try {
       set({ isExecuting: true, error: null });
       const results = await api.executeQuery(
         connectionId,
         `EXPLAIN ${sql}`,
+        database,
       );
       set({
         explainResult: results[0] ?? null,
@@ -107,12 +108,13 @@ export const useResultStore = create<ResultState>((set, get) => ({
     }
   },
 
-  executeExplainAnalyze: async (connectionId, sql) => {
+  executeExplainAnalyze: async (connectionId, sql, database) => {
     try {
       set({ isExecuting: true, error: null });
       const results = await api.executeQuery(
         connectionId,
         `EXPLAIN ANALYZE ${sql}`,
+        database,
       );
       set({
         explainResult: results[0] ?? null,

--- a/src/stores/resultStore.ts
+++ b/src/stores/resultStore.ts
@@ -111,11 +111,11 @@ export const useResultStore = create<ResultState>((set, get) => ({
   executeExplainAnalyze: async (connectionId, sql, database) => {
     try {
       set({ isExecuting: true, error: null });
-      const results = await api.executeQuery(
-        connectionId,
-        `EXPLAIN ANALYZE ${sql}`,
-        database,
-      );
+      const connState = useConnectionStore.getState();
+      const conn = connState.activeConnections.find((c) => c.id === connectionId);
+      const isMariaDB = conn?.server_version?.toLowerCase().includes("mariadb") ?? false;
+      const explainSql = isMariaDB ? `ANALYZE ${sql}` : `EXPLAIN ANALYZE ${sql}`;
+      const results = await api.executeQuery(connectionId, explainSql, database);
       set({
         explainResult: results[0] ?? null,
         explainAnalyze: true,

--- a/src/stores/resultStore.ts
+++ b/src/stores/resultStore.ts
@@ -11,6 +11,7 @@ interface ConfirmDialogState {
   isOpen: boolean;
   connectionId: string;
   sql: string;
+  database?: string;
 }
 
 interface ResultState {
@@ -25,7 +26,7 @@ interface ResultState {
 
   confirmDialog: ConfirmDialogState | null;
 
-  executeQuery: (connectionId: string, sql: string) => Promise<void>;
+  executeQuery: (connectionId: string, sql: string, database?: string) => Promise<void>;
   executeExplain: (connectionId: string, sql: string) => Promise<void>;
   executeExplainAnalyze: (connectionId: string, sql: string) => Promise<void>;
   setActiveResult: (index: number) => void;
@@ -56,20 +57,20 @@ export const useResultStore = create<ResultState>((set, get) => ({
 
   confirmDialog: null,
 
-  executeQuery: async (connectionId, sql) => {
+  executeQuery: async (connectionId, sql, database) => {
     // Production safety check
     if (isProductionConnection(connectionId) && DESTRUCTIVE_PATTERN.test(sql)) {
-      set({ confirmDialog: { isOpen: true, connectionId, sql } });
+      set({ confirmDialog: { isOpen: true, connectionId, sql, database } });
       return;
     }
-    await doExecuteQuery(connectionId, sql, set);
+    await doExecuteQuery(connectionId, sql, set, database);
   },
 
   confirmExecution: async () => {
     const dialog = get().confirmDialog;
     if (!dialog) return;
     set({ confirmDialog: null });
-    await doExecuteQuery(dialog.connectionId, dialog.sql, set);
+    await doExecuteQuery(dialog.connectionId, dialog.sql, set, dialog.database);
   },
 
   cancelExecution: () => {
@@ -129,6 +130,7 @@ async function doExecuteQuery(
   connectionId: string,
   sql: string,
   set: (partial: Partial<ResultState>) => void,
+  database?: string,
 ) {
   const startTime = Date.now();
   const connState = useConnectionStore.getState();
@@ -136,11 +138,16 @@ async function doExecuteQuery(
     (c) => c.id === connectionId,
   );
   const connectionName = conn?.name ?? "Unknown";
-  const database = conn?.database;
+  const effectiveDatabase = database ?? conn?.database;
+  const effectiveSql = effectiveDatabase
+    ? `USE \`${effectiveDatabase}\`;\n${sql}`
+    : sql;
 
   try {
     set({ isExecuting: true, error: null });
-    const results = await api.executeQuery(connectionId, sql);
+    const allResults = await api.executeQuery(connectionId, effectiveSql);
+    // Drop the result from the USE statement (first result if we prepended one)
+    const results = effectiveDatabase ? allResults.slice(1) : allResults;
     set({ results, activeResultIndex: 0, isExecuting: false });
 
     const totalRows = results.reduce((sum, r) => sum + r.rows.length, 0);
@@ -148,7 +155,7 @@ async function doExecuteQuery(
       id: crypto.randomUUID(),
       sql,
       connectionName,
-      database,
+      database: effectiveDatabase,
       executedAt: new Date().toISOString(),
       executionTimeMs: Date.now() - startTime,
       rowCount: totalRows,
@@ -161,7 +168,7 @@ async function doExecuteQuery(
       id: crypto.randomUUID(),
       sql,
       connectionName,
-      database,
+      database: effectiveDatabase,
       executedAt: new Date().toISOString(),
       executionTimeMs: Date.now() - startTime,
       rowCount: 0,

--- a/src/stores/resultStore.ts
+++ b/src/stores/resultStore.ts
@@ -138,16 +138,12 @@ async function doExecuteQuery(
     (c) => c.id === connectionId,
   );
   const connectionName = conn?.name ?? "Unknown";
+  // Explicit database selection takes precedence over the connection's default
   const effectiveDatabase = database ?? conn?.database;
-  const effectiveSql = effectiveDatabase
-    ? `USE \`${effectiveDatabase}\`;\n${sql}`
-    : sql;
 
   try {
     set({ isExecuting: true, error: null });
-    const allResults = await api.executeQuery(connectionId, effectiveSql);
-    // Drop the result from the USE statement (first result if we prepended one)
-    const results = effectiveDatabase ? allResults.slice(1) : allResults;
+    const results = await api.executeQuery(connectionId, sql, effectiveDatabase);
     set({ results, activeResultIndex: 0, isExecuting: false });
 
     const totalRows = results.reduce((sum, r) => sum + r.rows.length, 0);


### PR DESCRIPTION
## Bug fixes in this PR

- **Sidebar schema selection**: double-click to set active DB, query context passed correctly
- **Explain tab switching**: auto-switch to explain on explain result, back to results on run
- **MariaDB EXPLAIN ANALYZE**: use `ANALYZE SELECT` syntax on MariaDB instead of `EXPLAIN ANALYZE`
- **Autocomplete**: fix FROM context detection bug, add views, add column suggestions from FROM clause
- **`useQueryExecution` hook**: centralizes connection ID + database threading — eliminates entire class of wrong-DB bugs
- **QueryToolbar**: refactored to use the new hook
- **Version**: 0.1.0 → 0.1.1