### PR TITLE
fix: connection UX bugs (silent errors, stale edit form, timeout)

### DIFF
--- a/src-tauri/crates/mas-core/src/connection/manager.rs
+++ b/src-tauri/crates/mas-core/src/connection/manager.rs
@@ -55,7 +55,7 @@ impl ConnectionManager {
         let pool = MySqlPoolOptions::new()
             .min_connections(profile.pool_min)
             .max_connections(profile.pool_max)
-            .acquire_timeout(std::time::Duration::from_secs(10))
+            .acquire_timeout(std::time::Duration::from_secs(5))
             .idle_timeout(std::time::Duration::from_secs(300))
             .after_connect(|conn, _meta| {
                 Box::pin(async move {
@@ -163,7 +163,7 @@ impl ConnectionManager {
 
         match MySqlPoolOptions::new()
             .max_connections(1)
-            .acquire_timeout(std::time::Duration::from_secs(10))
+            .acquire_timeout(std::time::Duration::from_secs(5))
             .connect_with(options)
             .await
         {

--- a/src/components/connection/ConnectionDialog.tsx
+++ b/src/components/connection/ConnectionDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   X,
   Loader2,
@@ -88,6 +88,26 @@ export function ConnectionDialog({ isOpen, onClose, editProfile }: Props) {
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const saveProfile = useConnectionStore((s) => s.saveProfile);
+
+  useEffect(() => {
+    if (isOpen) {
+      setActiveTab("general");
+      setForm(
+        editProfile ??
+          ({
+            ...defaultProfile,
+            id: crypto.randomUUID(),
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          } as ConnectionProfile),
+      );
+      setSshEnabled(!!editProfile?.ssh_config);
+      setSshAuthMethod(
+        editProfile?.ssh_config?.private_key_path ? "key" : "password",
+      );
+      setTestResult(null);
+    }
+  }, [isOpen, editProfile]);
 
   if (!isOpen) return null;
 

--- a/src/components/layout/ConnectionTabs.tsx
+++ b/src/components/layout/ConnectionTabs.tsx
@@ -105,12 +105,16 @@ export function ConnectionTabs() {
 
   const handleConnectProfile = async (profileId: string) => {
     setPopoverOpen(false);
-    const conn = await connect(profileId);
-    setSelectedConnection(conn.id);
-    // Propagate the connection's auto-selected database to the active editor tab
-    const { activeTabId, setTabConnection } = useEditorStore.getState();
-    if (activeTabId) {
-      setTabConnection(activeTabId, conn.id, conn.database, conn.profile_id);
+    try {
+      const conn = await connect(profileId);
+      setSelectedConnection(conn.id);
+      // Propagate the connection's auto-selected database to the active editor tab
+      const { activeTabId, setTabConnection } = useEditorStore.getState();
+      if (activeTabId) {
+        setTabConnection(activeTabId, conn.id, conn.database, conn.profile_id);
+      }
+    } catch {
+      // Error is captured in connectionStore.error and shown in StatusBar
     }
   };
 

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -27,6 +27,8 @@ export function StatusBar() {
   const selectedConnectionId = useConnectionStore(
     (s) => s.selectedConnectionId,
   );
+  const connectionError = useConnectionStore((s) => s.error);
+  const clearConnectionError = useConnectionStore((s) => s.clearError);
   const isExecuting = useResultStore((s) => s.isExecuting);
   const results = useResultStore((s) => s.results);
   const activeResultIndex = useResultStore((s) => s.activeResultIndex);
@@ -107,6 +109,16 @@ export function StatusBar() {
         )}
       </div>
       <div className="flex items-center gap-3">
+        {connectionError && (
+          <button
+            onClick={clearConnectionError}
+            className="flex items-center gap-1 text-[10px] text-red-400 max-w-[300px] hover:text-red-300 transition-colors"
+            title="Connection error — click to dismiss"
+          >
+            <AlertCircle className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">{connectionError}</span>
+          </button>
+        )}
         {error && !isExecuting && (
           <button
             onClick={() => setShowFullError(!showFullError)}


### PR DESCRIPTION
## Summary

Three UX bugs fixed in the connection flow.

### 1. Clicking a saved connection did nothing
connectionStore.error was set on failure but never displayed. Unhandled promise rejections were silently swallowed by the webview.
- StatusBar now subscribes to connectionStore.error and shows it in red (click to dismiss)
- handleConnectProfile wraps connect() in try/catch to prevent silent rejections

### 2. Test/connect took 10 seconds on failure
acquire_timeout was explicitly set to 10s in both connect() and test_connection().
- Reduced to 5s

### 3. Edit Connection showed default/blank values
useState initializer only runs on first mount. The dialog stays mounted (returning null when closed), so reopening with a different editProfile showed stale form data.
- Added a useEffect that resets all form state when isOpen becomes true