### PR TITLE
feat(ai): Track tool name in ToolComplete events

### DIFF
--- a/src-tauri/crates/mas-ai/src/service.rs
+++ b/src-tauri/crates/mas-ai/src/service.rs
@@ -374,7 +374,7 @@ impl AiService {
         // Process events until idle/error
         let mut full_response = String::new();
         let event_conv_id = conv_id.clone();
-        let mut tool_calls: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let mut tool_calls: HashMap<String, String> = HashMap::new();
 
         loop {
             match events.recv().await {

--- a/src-tauri/crates/mas-ai/src/service.rs
+++ b/src-tauri/crates/mas-ai/src/service.rs
@@ -374,6 +374,7 @@ impl AiService {
         // Process events until idle/error
         let mut full_response = String::new();
         let event_conv_id = conv_id.clone();
+        let mut tool_calls: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
         loop {
             match events.recv().await {
@@ -402,6 +403,8 @@ impl AiService {
                             // Already accumulated deltas — nothing to do
                         }
                         SessionEventData::ToolExecutionStart(data) => {
+                            // Track tool name for the corresponding completion event
+                            tool_calls.insert(data.tool_call_id.clone(), data.tool_name.clone());
                             let _ = event_sender
                                 .send(AiStreamEvent::ToolStart {
                                     conversation_id: event_conv_id.clone(),
@@ -426,10 +429,16 @@ impl AiService {
                                 .map(|r| r.content.clone())
                                 .or_else(|| data.error.as_ref().map(|e| e.message.clone()))
                                 .unwrap_or_default();
+                            let tool_name = tool_calls
+                                .get(&data.tool_call_id)
+                                .cloned()
+                                .unwrap_or_default();
+                            // Remove from tracking after using
+                            tool_calls.remove(&data.tool_call_id);
                             let _ = event_sender
                                 .send(AiStreamEvent::ToolComplete {
                                     conversation_id: event_conv_id.clone(),
-                                    tool_name: String::new(), // not in complete data directly
+                                    tool_name,
                                     tool_call_id: data.tool_call_id.clone(),
                                     result: result_text,
                                     success: data.success,

--- a/src-tauri/crates/mas-ai/src/service.rs
+++ b/src-tauri/crates/mas-ai/src/service.rs
@@ -429,12 +429,16 @@ impl AiService {
                                 .map(|r| r.content.clone())
                                 .or_else(|| data.error.as_ref().map(|e| e.message.clone()))
                                 .unwrap_or_default();
-                            let tool_name = tool_calls
-                                .get(&data.tool_call_id)
-                                .cloned()
-                                .unwrap_or_default();
-                            // Remove from tracking after using
-                            tool_calls.remove(&data.tool_call_id);
+                            let tool_name = match tool_calls.remove(&data.tool_call_id) {
+                                Some(tool_name) => tool_name,
+                                None => {
+                                    tracing::warn!(
+                                        tool_call_id = %data.tool_call_id,
+                                        "ToolExecutionComplete received without a matching ToolExecutionStart"
+                                    );
+                                    "unknown".to_string()
+                                }
+                            };
                             let _ = event_sender
                                 .send(AiStreamEvent::ToolComplete {
                                     conversation_id: event_conv_id.clone(),


### PR DESCRIPTION
## Description
Adds proper tracking of tool calls to populate the 	ool_name field in ToolComplete events.

## Changes
- Added HashMap to track tool call IDs with their corresponding tool names
- Tool names are now properly populated when sending ToolComplete events to the frontend
- Improves frontend tool execution tracking and debugging

## Testing
- All tests pass: cargo test -p mas-ai
- No compilation errors or warnings