### PR TITLE
feat: configurable query row limit with truncation detection

### DIFF
--- a/src-tauri/crates/mas-ai/src/tools.rs
+++ b/src-tauri/crates/mas-ai/src/tools.rs
@@ -338,7 +338,7 @@ fn handle_run_select_query(
         trimmed.to_string()
     };
 
-    let results = block_on_async(executor.execute(connection_id, &limited_sql, None))
+    let results = block_on_async(executor.execute(connection_id, &limited_sql, None, None))
         .map_err(|e| e.to_string())?;
 
     format_query_results(&results)
@@ -350,7 +350,7 @@ fn handle_explain_query(
     sql: &str,
 ) -> Result<String, String> {
     let explain_sql = format!("EXPLAIN {}", sql.trim().trim_end_matches(';'));
-    let results = block_on_async(executor.execute(connection_id, &explain_sql, None))
+    let results = block_on_async(executor.execute(connection_id, &explain_sql, None, None))
         .map_err(|e| e.to_string())?;
 
     format_query_results(&results)
@@ -402,7 +402,7 @@ fn handle_run_query(
     connection_id: &str,
     sql: &str,
 ) -> Result<String, String> {
-    let results = block_on_async(executor.execute(connection_id, sql.trim(), None))
+    let results = block_on_async(executor.execute(connection_id, sql.trim(), None, None))
         .map_err(|e| e.to_string())?;
     format_query_results(&results)
 }

--- a/src-tauri/crates/mas-core/src/models/query.rs
+++ b/src-tauri/crates/mas-core/src/models/query.rs
@@ -9,6 +9,9 @@ pub struct QueryResult {
     pub rows_affected: u64,
     pub execution_time_ms: u64,
     pub warnings: Vec<String>,
+    pub rows_truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_rows_available: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/crates/mas-core/src/query/executor.rs
+++ b/src-tauri/crates/mas-core/src/query/executor.rs
@@ -174,7 +174,7 @@ impl QueryExecutor {
 
                             // Detect if rows may be truncated by our injected LIMIT
                             let rows_truncated =
-                                limit.is_some() && is_select && row_count as u64 >= limit.unwrap();
+                                limit.is_some() && is_select && row_count >= limit.unwrap();
 
                             results.push(QueryResult {
                                 query_id,
@@ -432,7 +432,7 @@ fn find_limit_keyword(upper: &str) -> Option<usize> {
     let mut end = end;
     if upper[..end].ends_with("OFFSET") {
         // Find "OFFSET" keyword
-        if let Some(pos) = find_keyword_offset(&upper, "OFFSET") {
+        if let Some(pos) = find_keyword_offset(upper, "OFFSET") {
             end = pos;
         }
     }

--- a/src-tauri/crates/mas-core/src/query/executor.rs
+++ b/src-tauri/crates/mas-core/src/query/executor.rs
@@ -21,8 +21,9 @@ impl QueryExecutor {
         connection_id: &str,
         sql: &str,
         database: Option<String>,
+        limit: Option<u64>,
     ) -> Result<Vec<QueryResult>, CoreError> {
-        self.execute_owned(connection_id.to_string(), sql.to_string(), database)
+        self.execute_owned(connection_id.to_string(), sql.to_string(), database, limit)
             .await
     }
 
@@ -32,9 +33,33 @@ impl QueryExecutor {
         connection_id: String,
         sql: String,
         database: Option<String>,
+        limit: Option<u64>,
     ) -> Result<Vec<QueryResult>, CoreError> {
         let pool = self.connection_manager.get_pool(&connection_id)?;
         let statements = split_statements(&sql);
+
+        // Apply global row limit to SELECT/SHOW/DESCRIBE statements
+        let statements: Vec<String> = if let Some(max_rows) = limit {
+            statements
+                .into_iter()
+                .map(|stmt| {
+                    let upper = stmt.trim().to_uppercase();
+                    if upper.starts_with("SELECT")
+                        || upper.starts_with("SHOW")
+                        || upper.starts_with("DESCRIBE")
+                        || upper.starts_with("EXPLAIN")
+                    {
+                        // Remove any existing LIMIT/OFFSET at the end before injecting our own
+                        let cleaned = strip_limit(&stmt);
+                        format!("{} LIMIT {}", cleaned, max_rows)
+                    } else {
+                        stmt
+                    }
+                })
+                .collect()
+        } else {
+            statements
+        };
 
         tracing::Span::current().record("statement_count", statements.len());
         tracing::trace!(sql = %sql, "Full SQL input");
@@ -55,9 +80,9 @@ impl QueryExecutor {
         let combined_sql = if let Some(db) = &database {
             let escaped_db = db.replace('`', "``");
             tracing::debug!(database = %db, "Switching database context");
-            format!("USE `{}`;\n{}", escaped_db, sql)
+            format!("USE `{}`;\n{}", escaped_db, statements.join("; "))
         } else {
-            sql
+            statements.join("; ")
         };
 
         // If USE db was prepended, skip its result (the first Either::Left).
@@ -147,6 +172,10 @@ impl QueryExecutor {
                                 "Query executed"
                             );
 
+                            // Detect if rows may be truncated by our injected LIMIT
+                            let rows_truncated =
+                                limit.is_some() && is_select && row_count as u64 >= limit.unwrap();
+
                             results.push(QueryResult {
                                 query_id,
                                 statement_index: idx,
@@ -155,6 +184,12 @@ impl QueryExecutor {
                                 rows_affected: row_count,
                                 execution_time_ms: execution_time,
                                 warnings: vec![],
+                                rows_truncated,
+                                total_rows_available: if rows_truncated {
+                                    Some(row_count)
+                                } else {
+                                    None
+                                },
                             });
                         } else {
                             let rows_affected = qr.rows_affected();
@@ -182,6 +217,8 @@ impl QueryExecutor {
                                 rows_affected,
                                 execution_time_ms: execution_time,
                                 warnings: vec![],
+                                rows_truncated: false,
+                                total_rows_available: None,
                             });
                         }
 
@@ -357,6 +394,81 @@ fn split_statements(sql: &str) -> Vec<String> {
     }
 
     statements
+}
+
+/// Strip trailing LIMIT/OFFSET from a SQL statement so we can inject our own global limit.
+/// Handles common patterns: LIMIT N, LIMIT M,N, LIMIT N OFFSET M
+fn strip_limit(stmt: &str) -> String {
+    let trimmed = stmt.trim();
+    let upper = trimmed.to_uppercase();
+
+    // Work backwards to find LIMIT keyword
+    // First check if statement ends with LIMIT pattern
+    if let Some(pos) = find_limit_keyword(&upper) {
+        let before_limit = trimmed[..pos].trim_end();
+        return before_limit.to_string();
+    }
+
+    trimmed.to_string()
+}
+
+/// Find the position of the LIMIT keyword at the end of a statement (case-insensitive).
+/// Returns None if no trailing LIMIT/OFFSET found.
+fn find_limit_keyword(upper: &str) -> Option<usize> {
+    let chars: Vec<char> = upper.chars().collect();
+    let len = chars.len();
+
+    // Skip trailing whitespace
+    let end = len
+        - chars[len - 1..]
+            .iter()
+            .take_while(|&&c| c.is_whitespace())
+            .count();
+    if end == 0 {
+        return None;
+    }
+
+    // Skip trailing OFFSET clause: ... OFFSET <number>
+    let mut end = end;
+    if upper[..end].ends_with("OFFSET") {
+        // Find "OFFSET" keyword
+        if let Some(pos) = find_keyword_offset(&upper, "OFFSET") {
+            end = pos;
+        }
+    }
+
+    // Now look for LIMIT keyword
+    find_keyword_offset(&upper[..end], "LIMIT")
+}
+
+/// Find position where a keyword starts at the end of the string (with number after it)
+fn find_keyword_offset(s: &str, keyword: &str) -> Option<usize> {
+    let upper = s.to_uppercase();
+    // Search for "LIMIT" followed by a digit, anywhere in the string
+    // We want the last occurrence that's followed by digits (not part of another word)
+    let mut last_pos = None;
+    let bytes = upper.as_bytes();
+    let keyword_bytes = keyword.as_bytes();
+
+    for i in 0..=bytes.len().saturating_sub(keyword_bytes.len()) {
+        if &bytes[i..i + keyword_bytes.len()] == keyword_bytes {
+            // Check it's not part of a larger word
+            let before_ok = i == 0 || bytes[i - 1] == b' ' || bytes[i - 1] == b'\t';
+            let after_pos = i + keyword_bytes.len();
+            let after_ok =
+                after_pos < bytes.len() && (bytes[after_pos] == b' ' || bytes[after_pos] == b'\t');
+
+            if before_ok && after_ok {
+                // Check there's a digit following
+                let rest = &upper[after_pos..].trim_start();
+                if rest.starts_with(|c: char| c.is_ascii_digit()) {
+                    last_pos = Some(i);
+                }
+            }
+        }
+    }
+
+    last_pos
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/mas-core/tests/integration_tests.rs
+++ b/src-tauri/crates/mas-core/tests/integration_tests.rs
@@ -188,7 +188,7 @@ async fn test_execute_select() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SELECT 1 AS num, 'hello' AS greeting", None)
+        .execute(&info.id, "SELECT 1 AS num, 'hello' AS greeting", None, None)
         .await
         .unwrap();
     assert_eq!(results.len(), 1);
@@ -210,6 +210,7 @@ async fn test_execute_select_from_table() {
         .execute(
             &info.id,
             "SELECT id, username, email FROM users ORDER BY id",
+            None,
             None,
         )
         .await
@@ -237,6 +238,7 @@ async fn test_execute_insert_update_delete() {
             &info.id,
             "INSERT INTO categories (name, description) VALUES ('Test Category', 'For testing')",
             None,
+            None,
         )
         .await
         .unwrap();
@@ -249,6 +251,7 @@ async fn test_execute_insert_update_delete() {
             &info.id,
             "UPDATE categories SET description = 'Updated' WHERE name = 'Test Category'",
             None,
+            None,
         )
         .await
         .unwrap();
@@ -259,6 +262,7 @@ async fn test_execute_insert_update_delete() {
         .execute(
             &info.id,
             "DELETE FROM categories WHERE name = 'Test Category'",
+            None,
             None,
         )
         .await
@@ -275,7 +279,7 @@ async fn test_execute_multi_statement() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SELECT 1; SELECT 2; SELECT 3", None)
+        .execute(&info.id, "SELECT 1; SELECT 2; SELECT 3", None, None)
         .await
         .unwrap();
     assert_eq!(
@@ -295,14 +299,14 @@ async fn test_execute_show_commands() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SHOW DATABASES", None)
+        .execute(&info.id, "SHOW DATABASES", None, None)
         .await
         .unwrap();
     assert_eq!(results.len(), 1);
     assert!(!results[0].rows.is_empty());
 
     let results = executor
-        .execute(&info.id, "SHOW TABLES", None)
+        .execute(&info.id, "SHOW TABLES", None, None)
         .await
         .unwrap();
     assert_eq!(results.len(), 1);
@@ -318,7 +322,7 @@ async fn test_execute_with_error() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let result = executor
-        .execute(&info.id, "SELECT * FROM nonexistent_table", None)
+        .execute(&info.id, "SELECT * FROM nonexistent_table", None, None)
         .await;
     assert!(result.is_err());
 
@@ -333,12 +337,13 @@ async fn test_execute_ddl() {
 
     // Create table
     let _ = executor
-        .execute(&info.id, "DROP TABLE IF EXISTS test_temp", None)
+        .execute(&info.id, "DROP TABLE IF EXISTS test_temp", None, None)
         .await;
     let results = executor
         .execute(
             &info.id,
             "CREATE TABLE test_temp (id INT PRIMARY KEY, name VARCHAR(50))",
+            None,
             None,
         )
         .await
@@ -347,18 +352,23 @@ async fn test_execute_ddl() {
 
     // Insert and select
     executor
-        .execute(&info.id, "INSERT INTO test_temp VALUES (1, 'test')", None)
+        .execute(
+            &info.id,
+            "INSERT INTO test_temp VALUES (1, 'test')",
+            None,
+            None,
+        )
         .await
         .unwrap();
     let results = executor
-        .execute(&info.id, "SELECT * FROM test_temp", None)
+        .execute(&info.id, "SELECT * FROM test_temp", None, None)
         .await
         .unwrap();
     assert_eq!(results[0].rows.len(), 1);
 
     // Clean up
     executor
-        .execute(&info.id, "DROP TABLE test_temp", None)
+        .execute(&info.id, "DROP TABLE test_temp", None, None)
         .await
         .unwrap();
 
@@ -375,6 +385,7 @@ async fn test_null_handling() {
         .execute(
             &info.id,
             "SELECT NULL AS null_val, 'not null' AS str_val",
+            None,
             None,
         )
         .await
@@ -397,7 +408,12 @@ async fn test_data_types() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SELECT * FROM data_types_test WHERE id = 1", None)
+        .execute(
+            &info.id,
+            "SELECT * FROM data_types_test WHERE id = 1",
+            None,
+            None,
+        )
         .await
         .unwrap();
     assert_eq!(results[0].rows.len(), 1);
@@ -420,6 +436,7 @@ async fn test_unicode_data() {
         .execute(
             &info.id,
             "SELECT id, content_utf8, content_emoji FROM unicode_test",
+            None,
             None,
         )
         .await
@@ -453,6 +470,7 @@ async fn test_json_data() {
         .execute(
             &info.id,
             "SELECT metadata FROM products WHERE metadata IS NOT NULL LIMIT 1",
+            None,
             None,
         )
         .await
@@ -658,6 +676,7 @@ async fn test_export_csv() {
             &info.id,
             "SELECT id, username, email FROM users LIMIT 3",
             None,
+            None,
         )
         .await
         .unwrap();
@@ -686,7 +705,12 @@ async fn test_export_json() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SELECT id, username FROM users LIMIT 2", None)
+        .execute(
+            &info.id,
+            "SELECT id, username FROM users LIMIT 2",
+            None,
+            None,
+        )
         .await
         .unwrap();
     let json = mas_export::export_json(&results[0]);
@@ -705,7 +729,12 @@ async fn test_export_sql_insert() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SELECT id, username FROM users LIMIT 1", None)
+        .execute(
+            &info.id,
+            "SELECT id, username FROM users LIMIT 1",
+            None,
+            None,
+        )
         .await
         .unwrap();
     let sql = mas_export::export_sql_insert(&results[0], "users");
@@ -731,7 +760,12 @@ async fn test_export_markdown() {
     let info = manager.connect(&test_profile()).await.unwrap();
 
     let results = executor
-        .execute(&info.id, "SELECT id, username FROM users LIMIT 2", None)
+        .execute(
+            &info.id,
+            "SELECT id, username FROM users LIMIT 2",
+            None,
+            None,
+        )
         .await
         .unwrap();
     let md = mas_export::export_markdown(&results[0]);

--- a/src-tauri/crates/mas-core/tests/query_database_context_regression.rs
+++ b/src-tauri/crates/mas-core/tests/query_database_context_regression.rs
@@ -36,6 +36,7 @@ async fn test_execute_select_with_explicit_database_context() {
             &info.id,
             "SELECT id, username FROM users ORDER BY id LIMIT 1",
             Some("test_db".to_string()),
+            None,
         )
         .await
         .unwrap();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -148,10 +148,11 @@ pub async fn execute_query(
     connection_id: String,
     sql: String,
     database: Option<String>,
+    limit: Option<u64>,
 ) -> Result<Vec<QueryResult>, String> {
     let results = state
         .query_executor
-        .execute_owned(connection_id, sql, database)
+        .execute_owned(connection_id, sql, database, limit)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Query execution failed");

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ import {
 import { useConnectionStore } from "../../stores/connectionStore";
 import { useEditorStore } from "../../stores/editorStore";
 import { useResultStore } from "../../stores/resultStore";
+import { useSettingsStore } from "../../stores/settingsStore";
 import { QueryHistory } from "../history/QueryHistory";
 import { QueryFavorites } from "../favorites/QueryFavorites";
 import { cn } from "../../lib/utils";
@@ -257,17 +258,18 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
 
   // Single click: run SELECT inline without touching the editor tab
   // Double click (within 250ms): insert table name at cursor instead
+  const { maxResultRows } = useSettingsStore.getState().querySettings;
   const handleTableClick = (dbName: string, tableName: string) =>
     makeClickHandler(
       `${dbName}.${tableName}`,
-      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${tableName}\` LIMIT 100`, dbName),
+      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${tableName}\` LIMIT ${maxResultRows}`, dbName),
       () => insertNameAtCursor(tableName),
     );
 
   const handleViewClick = (dbName: string, viewName: string) =>
     makeClickHandler(
       `${dbName}.${viewName}`,
-      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${viewName}\` LIMIT 100`, dbName),
+      () => executeQuery(connectionId, `SELECT * FROM \`${dbName}\`.\`${viewName}\` LIMIT ${maxResultRows}`, dbName),
       () => insertNameAtCursor(viewName),
     );
 
@@ -480,7 +482,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                             label: "Select Top 100 Rows",
                             icon: <Search className="h-3.5 w-3.5" />,
                             onClick: () => {
-                              executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${t.name}\` LIMIT 100`, db.name);
+                              executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${t.name}\` LIMIT ${maxResultRows}`, db.name);
                             },
                           },
                           {
@@ -584,7 +586,7 @@ function SchemaTree({ connectionId }: { connectionId: string }) {
                           label: "Select Top 100 Rows",
                           icon: <Search className="h-3.5 w-3.5" />,
                           onClick: () => {
-                            executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${v.name}\` LIMIT 100`, db.name);
+                            executeQuery(connectionId, `SELECT * FROM \`${db.name}\`.\`${v.name}\` LIMIT ${maxResultRows}`, db.name);
                           },
                         },
                         {

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -58,8 +58,8 @@ export const api = {
     tauriInvoke<ConnectionInfo[]>("list_connections"),
 
   // Queries
-  executeQuery: (connectionId: string, sql: string, database?: string) =>
-    tauriInvoke<QueryResult[]>("execute_query", { connectionId, sql, database }),
+  executeQuery: (connectionId: string, sql: string, database?: string, limit?: number) =>
+    tauriInvoke<QueryResult[]>("execute_query", { connectionId, sql, database, limit }),
 
   // Schema
   getDatabases: (connectionId: string) =>

--- a/src/stores/__tests__/resultStore.test.ts
+++ b/src/stores/__tests__/resultStore.test.ts
@@ -22,6 +22,8 @@ describe("resultStore", () => {
           rows_affected: 0,
           execution_time_ms: 10,
           warnings: [],
+          rows_truncated: false,
+          total_rows_available: 0,
         },
       ],
     });

--- a/src/stores/resultStore.ts
+++ b/src/stores/resultStore.ts
@@ -3,6 +3,7 @@ import type { QueryResult } from "../types";
 import { api } from "../lib/tauri-api";
 import { useHistoryStore } from "./historyStore";
 import { useConnectionStore } from "./connectionStore";
+import { useSettingsStore } from "./settingsStore";
 
 const DESTRUCTIVE_PATTERN =
   /\b(DROP|DELETE|TRUNCATE|ALTER)\b/i;
@@ -143,9 +144,13 @@ async function doExecuteQuery(
   // Explicit database selection takes precedence over the connection's default
   const effectiveDatabase = database ?? conn?.database;
 
+  // Compute row limit from settings
+  const { limitEnabled, maxResultRows } = useSettingsStore.getState().querySettings;
+  const rowLimit = limitEnabled ? maxResultRows : undefined;
+
   try {
     set({ isExecuting: true, error: null });
-    const results = await api.executeQuery(connectionId, sql, effectiveDatabase);
+    const results = await api.executeQuery(connectionId, sql, effectiveDatabase, rowLimit);
     set({ results, activeResultIndex: 0, isExecuting: false });
 
     const totalRows = results.reduce((sum, r) => sum + r.rows.length, 0);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,5 +1,15 @@
 import { create } from "zustand";
 
+export interface QuerySettings {
+  maxResultRows: number;
+  limitEnabled: boolean;
+}
+
+const DEFAULT_QUERY_SETTINGS: QuerySettings = {
+  maxResultRows: 1000,
+  limitEnabled: true,
+};
+
 export interface FormatterSettings {
   keywordCase: "upper" | "lower" | "preserve";
   identifierCase: "upper" | "lower" | "preserve";
@@ -30,7 +40,20 @@ const DEFAULT_FORMATTER_SETTINGS: FormatterSettings = {
   denseOperators: false,
 };
 
+const QUERY_SETTINGS_KEY = "sqlpilot-query-settings";
 const STORAGE_KEY = "sqlpilot-formatter-settings";
+
+function loadQuerySettings(): QuerySettings {
+  try {
+    const stored = localStorage.getItem(QUERY_SETTINGS_KEY);
+    if (stored) {
+      return { ...DEFAULT_QUERY_SETTINGS, ...JSON.parse(stored) };
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_QUERY_SETTINGS;
+}
 
 function loadSettings(): FormatterSettings {
   try {
@@ -45,12 +68,24 @@ function loadSettings(): FormatterSettings {
 }
 
 interface SettingsState {
+  querySettings: QuerySettings;
   formatterSettings: FormatterSettings;
+  setQuerySettings: (settings: QuerySettings) => void;
   setFormatterSettings: (settings: FormatterSettings) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
+  querySettings: loadQuerySettings(),
   formatterSettings: loadSettings(),
+
+  setQuerySettings: (settings) => {
+    try {
+      localStorage.setItem(QUERY_SETTINGS_KEY, JSON.stringify(settings));
+    } catch {
+      // localStorage unavailable
+    }
+    set({ querySettings: settings });
+  },
 
   setFormatterSettings: (settings) => {
     try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,8 @@ export interface QueryResult {
   rows_affected: number;
   execution_time_ms: number;
   warnings: string[];
+  rows_truncated: boolean;
+  total_rows_available?: number;
 }
 
 export interface ColumnMeta {


### PR DESCRIPTION
## Problem

Running SELECT * FROM large_table on a table with millions of rows causes the frontend to crash with an **Out-of-Memory error**. The backend fetches all rows, serializes them to JSON, and sends the entire payload over IPC.

## Solution

Add a configurable **max result rows** setting that automatically limits SELECT, SHOW, DESCRIBE, and EXPLAIN queries. When the limit is hit, the UI shows a truncation warning.

### Changes

**Backend (Rust):**
- Add limit: Option&lt;u64&gt; parameter to QueryExecutor::execute()
- Strip any existing LIMIT/OFFSET from user queries before injecting the global limit
- Detect when rows may be truncated, set rows_truncated flag and total_rows_available
- Default: None (no limit) at the command level; frontend passes the configured value

**Frontend (TypeScript):**
- Add QuerySettings to settingsStore (maxResultRows, limitEnabled), persisted in localStorage
- Wire settings through resultStore -&gt; tauri-api -&gt; Rust command
- Update Sidebar table/view queries to use the configurable value
- Add rows_truncated and total_rows_available to QueryResult type

**Defaults:** 1000 rows max, limit enabled by default.
