### PR TITLE
chore: upgrade zustand from v4 to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-resizable-panels": "^4.0.0",
         "sql-formatter": "^15.7.3",
         "tailwind-merge": "^3.5.0",
-        "zustand": "^4.5.0"
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -5584,15 +5584,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5996,20 +5987,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6019,6 +6008,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-resizable-panels": "^4.0.0",
     "sql-formatter": "^15.7.3",
     "tailwind-merge": "^3.5.0",
-    "zustand": "^4.5.0"
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/hooks/__tests__/useQueryExecution.test.ts
+++ b/src/hooks/__tests__/useQueryExecution.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
     selectedConnectionId: null,
     activeConnections: [],
     profiles: [],
-  } as Parameters<typeof useConnectionStore.setState>[0]);
+  } as unknown as Parameters<typeof useConnectionStore.setState>[0]);
 
   useEditorStore.setState({ tabs: [], activeTabId: null });
 
@@ -35,7 +35,7 @@ beforeEach(() => {
     executeQuery: mockExecuteQuery,
     executeExplain: mockExecuteExplain,
     executeExplainAnalyze: mockExecuteExplainAnalyze,
-  } as Parameters<typeof useResultStore.setState>[0]);
+  } as unknown as Parameters<typeof useResultStore.setState>[0]);
 });
 
 describe("useQueryExecution", () => {


### PR DESCRIPTION
Upgrades zustand from 4.5.0 to 5.0.12. Zustand v5 has stricter setState typing. Store creation API unchanged, no production code changes needed. Test fix: updated useQueryExecution.test.ts to cast partial state objects via unknown. All 275 tests pass, lint clean, type-check clean.