### PR TITLE
Fix deleteProfile loading state

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,6 @@ use mas_core::schema::SchemaInspector;
 use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use tauri::Emitter;
-use tauri::Manager;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 

--- a/src/components/editor/__tests__/QueryToolbar.test.tsx
+++ b/src/components/editor/__tests__/QueryToolbar.test.tsx
@@ -59,6 +59,7 @@ vi.mock("../../../hooks/useSchemaCache", () => ({
 
 let mockAiEnabled = true;
 const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+const mockSetQuerySettings = vi.fn();
 
 vi.mock("../../../stores/aiStore", () => ({
   useAiStore: Object.assign(
@@ -75,26 +76,37 @@ vi.mock("../../../stores/aiStore", () => ({
   ),
 }));
 
+const mockSettingsState = {
+  querySettings: {
+    maxResultRows: 1000,
+    limitEnabled: true,
+  },
+  formatterSettings: {
+    keywordCase: "upper",
+    identifierCase: "preserve",
+    dataTypeCase: "upper",
+    functionCase: "preserve",
+    indentStyle: "standard",
+    tabWidth: 2,
+    useTabs: false,
+    logicalOperatorNewline: "before",
+    newlineBeforeSemicolon: false,
+    expressionWidth: 50,
+    linesBetweenQueries: 1,
+    denseOperators: false,
+  },
+  setQuerySettings: mockSetQuerySettings,
+};
+
 vi.mock("../../../stores/settingsStore", () => ({
-  useSettingsStore: vi.fn((selector?: (s: any) => any) => {
-    const state = {
-      formatterSettings: {
-        keywordCase: "upper",
-        identifierCase: "preserve",
-        dataTypeCase: "upper",
-        functionCase: "preserve",
-        indentStyle: "standard",
-        tabWidth: 2,
-        useTabs: false,
-        logicalOperatorNewline: "before",
-        newlineBeforeSemicolon: false,
-        expressionWidth: 50,
-        linesBetweenQueries: 1,
-        denseOperators: false,
-      },
-    };
-    return selector ? selector(state) : state;
-  }),
+  useSettingsStore: Object.assign(
+    vi.fn((selector?: (s: any) => any) => {
+      return selector ? selector(mockSettingsState) : mockSettingsState;
+    }),
+    {
+      getState: vi.fn(() => mockSettingsState),
+    },
+  ),
 }));
 
 let mockEditorInstance: any = {
@@ -198,6 +210,7 @@ describe("QueryToolbar", () => {
     mockExecuteExplain.mockClear();
     mockExecuteExplainAnalyze.mockClear();
     mockSendMessage.mockClear();
+    mockSetQuerySettings.mockClear();
   });
 
   it("renders the Run button", () => {

--- a/src/stores/__tests__/connectionStore.test.ts
+++ b/src/stores/__tests__/connectionStore.test.ts
@@ -50,6 +50,16 @@ const mockConnectionProfile: ConnectionProfile = {
   password: "secret",
 };
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("connectionStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -143,12 +153,30 @@ describe("connectionStore", () => {
       expect(useConnectionStore.getState().profiles).toEqual([]);
     });
 
+    it("sets loading to true and clears previous error during delete", async () => {
+      const deleteRequest = deferred<void>();
+      vi.mocked(api.deleteConnectionProfile).mockReturnValue(deleteRequest.promise);
+      vi.mocked(api.listConnectionProfiles).mockResolvedValue([]);
+      useConnectionStore.setState({ error: "Previous error" });
+
+      const promise = useConnectionStore.getState().deleteProfile("profile-1");
+
+      expect(useConnectionStore.getState().loading).toBe(true);
+      expect(useConnectionStore.getState().error).toBeNull();
+
+      deleteRequest.resolve();
+      await promise;
+
+      expect(useConnectionStore.getState().loading).toBe(false);
+    });
+
     it("handles deleteProfile error", async () => {
       vi.mocked(api.deleteConnectionProfile).mockRejectedValue(new Error("Delete failed"));
 
       await useConnectionStore.getState().deleteProfile("profile-1");
 
       expect(useConnectionStore.getState().error).toBe("Error: Delete failed");
+      expect(useConnectionStore.getState().loading).toBe(false);
     });
   });
 

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -51,10 +51,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   deleteProfile: async (id) => {
     try {
+      set({ loading: true, error: null });
       await api.deleteConnectionProfile(id);
       await get().loadProfiles();
     } catch (e) {
-      set({ error: String(e) });
+      set({ error: String(e), loading: false });
     }
   },
 


### PR DESCRIPTION
## Summary
- Set `loading` and clear stale errors when `deleteProfile` starts.
- Reset `loading` on delete failure.
- Add regression coverage for delete loading/error state.
- Update the QueryToolbar settings-store test mock so the full unit suite matches the current query-settings contract.

## Tests
- `npm run test:unit -- src/stores/__tests__/connectionStore.test.ts`
- `npm run test:unit -- src/components/editor/__tests__/QueryToolbar.test.tsx`
- `npm run test:unit`
- `npm run type-check`
- `npm run lint`
- `git diff --check`
- `npm run build`

Fixes #114
